### PR TITLE
adds input type to form field

### DIFF
--- a/wiki/Datencockpit-Strukturen.xml
+++ b/wiki/Datencockpit-Strukturen.xml
@@ -9267,7 +9267,7 @@ Existierende Benutzer können auf freiwilliger Basis persönliche Informationen 
 |-
 |Dokument:
 |{{#info:Hier können Sie ein Dokument hochladen, falls z. B. eine schriftliche Folgenabschätzung als PDF-Bericht vorliegt.}}
-|{{{field|Dokument|uploadable|class=form-control}}}
+|{{{field|Dokument|input type=text|uploadable|class=form-control}}}
 |-
 |Aufgabe für:
 |{{#info:BenutzerInnen können Aufgaben zugewiesen werden, die in der Liste auf ihrer Benutzerseite angezeigt werden.}}


### PR DESCRIPTION
Formular:Folge won't accept any file uploads. 

"uploadable" needs text input type: 
See: https://www.mediawiki.org/wiki/Extension:Page_Forms/Input_types#Uploading_files

"""Note that you must also add "input type=text" to the respective field declaration; otherwise "uploadable" will not work."""